### PR TITLE
move some computations out of bootstrap

### DIFF
--- a/R/unit_zi.R
+++ b/R/unit_zi.R
@@ -188,6 +188,11 @@ unit_zi <- function(samp_dat,
         paste(log_X, collapse = " + ")
       )
     )
+    # define these before bootstrap
+    boot_truth <- stats::setNames(stats::aggregate(response ~ domain, data = boot_pop_data,
+                                                   FUN = mean), c("domain", "domain_est"))
+    
+    by_domains <- split(boot_pop_data, f = boot_pop_data$domain)
 
     # furrr with progress bar
     boot_rep_with_progress_bar <- function(x) {
@@ -201,7 +206,9 @@ unit_zi <- function(samp_dat,
           samp_dat,
           domain_level,
           boot_lin_formula,
-          boot_log_formula
+          boot_log_formula,
+          boot_truth,
+          by_domains
         )
         },
         .options = furrr_options(seed = TRUE))

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,12 +72,9 @@ boot_rep <- function(pop_boot,
                      samp_dat,
                      domain_level,
                      boot_lin_formula,
-                     boot_log_formula) {
-  
-  boot_truth <- stats::setNames(stats::aggregate(response ~ domain, data = pop_boot,
-                                                 FUN = mean), c("domain", "domain_est"))
-  
-  by_domains <- split(pop_boot, f = pop_boot$domain)
+                     boot_log_formula,
+                     boot_truth,
+                     by_domains) {
   
   num_domains <- length(by_domains)
   num_plots <- data.frame(table(samp_dat[ , domain_level]))


### PR DESCRIPTION
This defines our bootstrap population parameters outside of the bootstrap function in order to save computational time + memory in parallel