### PR TITLE
fixes issue in removing preds that only occur in the logistic formula

### DIFF
--- a/R/saeczi.R
+++ b/R/saeczi.R
@@ -88,7 +88,7 @@ saeczi <- function(samp_dat,
   lin_formula <- reformulate(c(lin_X, rand_intercept), response = Y)
   log_formula <- reformulate(c(log_X, rand_intercept), response = paste0(Y, "!= 0"))
 
-  all_preds <- unique(lin_X, log_X)
+  all_preds <- unique(c(lin_X, log_X))
 
   original_out <- fit_zi(samp_dat,
                          lin_formula,


### PR DESCRIPTION
Small typo causing issues when `select()`ing columns to keep in the input datasets. 

Before we had `unique(a, b)`, which I have updated to `unique(c(a, b))`. If `a <- c("Millie", "Tucker")` and `b <- c("Millie", "Tucker", "Dude")`, `unique(a, b)` leaves Dude out, while `unique(c(a, b))` keeps all three. 